### PR TITLE
Rewrite of send_to_dev_ci.sh

### DIFF
--- a/dev_CI/send_to_dev_ci.sh
+++ b/dev_CI/send_to_dev_ci.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage:
 # send_to_dev_ci.sh
@@ -11,51 +11,55 @@
 script_dir="$(dirname "$(realpath "$0")")"
 
 # Get potential arguments and store them into an array
-if [ $# -ge 1 ]
-then
+if [ $# -ge 1 ]; then
     folders_to_send=("$@")
+else
+    folders_to_send=(
+        "$script_dir/APP1"
+        "$script_dir/APP2"
+        "$script_dir/APP3"
+    )
 fi
 
-ssh_user=USER_NAME
+ssh_user=USERNAME
 ssh_host=ci-apps-dev.yunohost.org
 ssh_port=22
-ssh_key=~/.ssh/PRIVATE_KEY
+ssh_key=~/.ssh/USER_SSH_KEY
 distant_dir=/data
 SSHSOCKET=~/.ssh/ssh-socket-%r-%h-%p
 
 SEND_TO_CI () {
+    # Dirs specified as local[:distant]
+    # distant = basename(local) if not specified
+
+    IFS=':' read -ra dirs <<< "${1}"
+
+    # Rsync needs trailing slash
+    source_dir="$(realpath "${dirs[0]}")"
+    [[ "${source_dir}" != */ ]] && source_dir="${source_dir}/"
+
+    target_dir="${dirs[1]}"
+    : "${target_dir:="$(basename "${source_dir}")"}"
+
     echo "============================"
-    echo ">>> Sending $1"
-    rsync -avzhuE -c --progress --delete --exclude=".git" "${1%/}" -e "ssh -i $ssh_key -p $ssh_port -o ControlPath=$SSHSOCKET"  $ssh_user@$ssh_host:"$distant_dir/"
+    echo ">>> Sending $source_dir to $target_dir"
+    rsync -avzhuE -c --progress --delete --exclude=".git" "${source_dir}" -e "ssh -i $ssh_key -p $ssh_port -o ControlPath=$SSHSOCKET"  $ssh_user@$ssh_host:"$distant_dir/$target_dir"
     echo "============="
     echo "Build should show up here once it starts:"
-    echo "https://$ssh_host/jenkins/view/$ssh_user/job/$(basename "${1%/}")%20($ssh_user)/lastBuild/console"
+    echo "https://$ssh_host/jenkins/job/${target_dir}%20(${ssh_user})/lastBuild/console"
 }
 
 echo "Opening connection"
-ssh $ssh_user@$ssh_host -p $ssh_port -i $ssh_key -f -M -N -o ControlPath=$SSHSOCKET
-if [ "$?" -ne 0 ]
-then
+if ! ssh $ssh_user@$ssh_host -p $ssh_port -i $ssh_key -f -M -N -o ControlPath=$SSHSOCKET; then
     # If the user wait too long, the connection will fail.
     # Same player try again
     ssh $ssh_user@$ssh_host -p $ssh_port -i $ssh_key -f -M -N -o ControlPath=$SSHSOCKET
 fi
 
-# If the script has arguments, use them
-if [ -n "$folders_to_send" ]
-then
-    # Read each arguments separately
-    for folder in "${folders_to_send[@]}"
-    do
-        SEND_TO_CI "$folder"
-    done
-
-# Otherwise, without arguments, use the static list
-else
-    SEND_TO_CI "$script_dir/APP1"
-    SEND_TO_CI "$script_dir/APP2"
-    SEND_TO_CI "$script_dir/APP3"
-fi
+# Read each arguments separately
+for folder in "${folders_to_send[@]}"; do
+    SEND_TO_CI "$folder"
+done
 
 echo "Closing connection"
 ssh $ssh_user@$ssh_host -p $ssh_port -i $ssh_key -S $SSHSOCKET -O exit


### PR DESCRIPTION
Changes implemented :
* General cleanup of the script

* The default distant dir name is now the local dir name, not the argument given to the script:
  Now, `../send_to_dev_ci.sh .` will create a distant dir with the same name as local's `.`.

* You can specify a different name for the distant dir name :
  * `./send_dev_ci.sh my_app_ynh` will copy in directory `my_app_ynh`
  * `./send_dev_ci.sh my_app_ynh:my_app_ynh_XXX` will copy in directory `my_app_ynh_XXX`